### PR TITLE
Remove redundant .NET Core SDK 2 installation in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,10 +21,6 @@ clone_depth: 1
 nuget:
   disable_publish_on_pr: true
 
-install:
-  - cmd: curl -O https://download.microsoft.com/download/0/F/D/0FD852A4-7EA1-4E2A-983A-0484AC19B92C/dotnet-sdk-2.0.0-win-x64.exe
-  - cmd: dotnet-sdk-2.0.0-win-x64.exe /install /quiet /norestart /log install.log
-
 #---------------------------------#
 #       build configuration       #
 #---------------------------------#


### PR DESCRIPTION
AppVeyor VS 2017 image now includes it as of [August 17](https://www.appveyor.com/updates/2017/08/17/).