### PR TITLE
Receive HttpMessageHandler in SmartCacheHttpClient instead of HttpClientHandler

### DIFF
--- a/src/SmartCache.Client/Http/IHttpClientFactory.cs
+++ b/src/SmartCache.Client/Http/IHttpClientFactory.cs
@@ -4,6 +4,6 @@ namespace SmartCache.Client.Http
 {
     public interface IHttpClientFactory
     {
-        IHttpClient Create(HttpClientHandler handler);
+        IHttpClient Create(HttpMessageHandler handler);
     }
 }

--- a/src/SmartCache.Client/Http/SmartCacheHttpClient.cs
+++ b/src/SmartCache.Client/Http/SmartCacheHttpClient.cs
@@ -9,7 +9,7 @@ namespace SmartCache.Client.Http
     {
         private readonly HttpClient client;
 
-        public SmartCacheHttpClient(HttpClientHandler handler)
+        public SmartCacheHttpClient(HttpMessageHandler handler)
         {
             client = new HttpClient(handler);
         }

--- a/src/SmartCache.Client/Http/SmartCacheHttpClientFactory.cs
+++ b/src/SmartCache.Client/Http/SmartCacheHttpClientFactory.cs
@@ -4,7 +4,7 @@ namespace SmartCache.Client.Http
 {
     public class SmartCacheHttpClientFactory : IHttpClientFactory
     {
-        public IHttpClient Create(HttpClientHandler handler)
+        public IHttpClient Create(HttpMessageHandler handler)
         {
             return new SmartCacheHttpClient(handler);
         }

--- a/src/SmartCache.Client/SmartCache.Client.csproj
+++ b/src/SmartCache.Client/SmartCache.Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/SmartCache.Client.IntegrationTests/CustomDelegatingHandler.cs
+++ b/test/SmartCache.Client.IntegrationTests/CustomDelegatingHandler.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SmartCache.Client.IntegrationTests
+{
+    public class CustomDelegatingHandler : DelegatingHandler
+    {
+        private Action delegatingHandlerCallBack;
+
+        public CustomDelegatingHandler(HttpMessageHandler handler, Action delegatingHandlerCallBack)
+        {
+            InnerHandler = handler;
+            this.delegatingHandlerCallBack = delegatingHandlerCallBack;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = base.SendAsync(request, cancellationToken);
+            delegatingHandlerCallBack();
+
+            return response;
+        }
+    }
+}

--- a/test/SmartCache.Client.IntegrationTests/CustomSmartCacheHttpClientFactory.cs
+++ b/test/SmartCache.Client.IntegrationTests/CustomSmartCacheHttpClientFactory.cs
@@ -1,0 +1,21 @@
+﻿using SmartCache.Client.Http;
+using System;
+using System.Net.Http;
+
+namespace SmartCache.Client.IntegrationTests
+{
+    public class CustomSmartCacheHttpClientFactory : IHttpClientFactory
+    {
+        private Action delegatingHandlerCallBack;
+
+        public CustomSmartCacheHttpClientFactory(Action delegatingHandlerCallBack)
+        {
+            this.delegatingHandlerCallBack = delegatingHandlerCallBack;
+        }
+
+        public IHttpClient Create(HttpMessageHandler handler)
+        {
+            return new SmartCacheHttpClient(new CustomDelegatingHandler(handler, delegatingHandlerCallBack));
+        }
+    }
+}

--- a/test/SmartCache.Client.IntegrationTests/SmartCacheClientTest.cs
+++ b/test/SmartCache.Client.IntegrationTests/SmartCacheClientTest.cs
@@ -29,7 +29,7 @@ namespace SmartCache.Client.IntegrationTests
         }
 
         [Fact]
-        public async Task GetAsync_CallJApiWithCustomHttpClientFactoryAndDelegatingHandler_ShouldUseTheCustomDeletagatingHandler()
+        public async Task GetAsync_CallApiWithCustomHttpClientFactoryAndDelegatingHandler_ShouldUseTheCustomDeletagatingHandler()
         {
             var delegatingHandlerUsed = false;
 

--- a/test/SmartCache.Client.IntegrationTests/SmartCacheClientTest.cs
+++ b/test/SmartCache.Client.IntegrationTests/SmartCacheClientTest.cs
@@ -27,5 +27,21 @@ namespace SmartCache.Client.IntegrationTests
 
             Assert.Equal(null, result);
         }
+
+        [Fact]
+        public async Task GetAsync_CallJApiWithCustomHttpClientFactoryAndDelegatingHandler_ShouldUseTheCustomDeletagatingHandler()
+        {
+            var delegatingHandlerUsed = false;
+
+            Action delegatingHandlerCallBack = () => { delegatingHandlerUsed = true; };
+
+            var sut = new SmartCacheClient(new SmartCacheHttpClientBuilder(new EmptyClientCertProvider(), new CustomSmartCacheHttpClientFactory(delegatingHandlerCallBack)));
+
+            var result = await sut.GetAsync<Post>(new Uri("https://jsonplaceholder.typicode.com/posts/3"));
+
+            Assert.NotNull(result);
+            Assert.Equal(3, result.Id);
+            Assert.True(delegatingHandlerUsed);
+        }
     }
 }


### PR DESCRIPTION
We need to set a custom HttpMessageHandler in the HTTP Requests. In order to achieve it, I replaced the  _HttpClientHandler_ by its base type _HttpMessageHandler_. In that way I can use a custom _DelegatingHandler_ and set the default handler as _InnerHandler_ (vide tests).

